### PR TITLE
Adds Context struct and related methods.

### DIFF
--- a/proj/context.go
+++ b/proj/context.go
@@ -1,0 +1,74 @@
+package proj
+
+import (
+	"fmt"
+	"github.com/everystreet/go-proj/v6/cproj"
+)
+
+type Context struct {
+	context *cproj.PJ_CONTEXT
+
+	src        *cproj.PJ
+	dst        *cproj.PJ
+	pj         *cproj.PJ
+	normalized *cproj.PJ
+}
+
+func CreateContext(source, target string) (*Context, error) {
+	ctx := &Context{}
+	ctx.context = cproj.Context_create()
+
+	src, err := CRS(source).instantiate(ctx.context)
+	if err != nil {
+		defer ctx.Destroy()
+		return nil, fmt.Errorf("invalid source '%v': %w", source, err)
+	}
+	ctx.src = src
+
+	dst, err := CRS(target).instantiate(ctx.context)
+	if err != nil {
+		defer ctx.Destroy()
+		return nil, fmt.Errorf("invalud target '%v': %w", target, err)
+	}
+	ctx.dst = dst
+
+	ctx.pj = cproj.Create_crs_to_crs_from_pj(ctx.context, src, dst, nil, nil)
+	if ctx.pj == nil {
+		defer ctx.Destroy()
+		return nil, fmt.Errorf("invalid source or target CRS")
+	}
+
+	ctx.normalized = cproj.Normalize_for_visualization(ctx.context, ctx.pj)
+	if ctx.normalized == nil {
+		defer ctx.Destroy()
+		return nil, fmt.Errorf("failed to normalize")
+	}
+
+	return ctx, nil
+}
+
+func (c *Context) Destroy() {
+	if c.context != nil {
+		cproj.Context_destroy(c.context)
+	}
+	if c.src != nil {
+		cproj.Destroy(c.src)
+	}
+	if c.dst != nil {
+		cproj.Destroy(c.dst)
+	}
+	if c.pj != nil {
+		cproj.Destroy(c.pj)
+	}
+	if c.normalized != nil {
+		cproj.Destroy(c.normalized)
+	}
+}
+
+func (c *Context) TransformForward(coord Coordinate) {
+	transform(c.normalized, forward, coord)
+}
+
+func (c *Context) TransformInverse(coord Coordinate) {
+	transform(c.normalized, inverse, coord)
+}

--- a/proj/transform_test.go
+++ b/proj/transform_test.go
@@ -2,6 +2,7 @@ package proj_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/everystreet/go-proj/v6/proj"
 )
@@ -22,4 +23,36 @@ func ExampleCRSToCRS() {
 
 	fmt.Printf("%.2f %.2f %.2f", coord.X, coord.Y, coord.Z)
 	// Output: 222638.98 6274861.39 10.00
+}
+
+func BenchmarkCRSToCRS(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		coord := proj.XYZ{
+			X: 2,
+			Y: 49,
+			Z: 10,
+		}
+
+		if err := proj.CRSToCRS("+proj=latlong", "EPSG:3857", func(pj proj.Projection) {
+			proj.TransformForward(pj, &coord)
+			// transform more coordinates
+		}); err != nil {
+			panic(err)
+		}
+	}
+}
+
+func BenchmarkContext(b *testing.B) {
+	var context, _ = proj.CreateContext("+proj=latlong", "EPSG:3857")
+	defer context.Destroy()
+
+	for i := 0; i < b.N; i++ {
+		coord := proj.XYZ{
+			X: 2,
+			Y: 49,
+			Z: 10,
+		}
+
+		context.TransformInverse(&coord)
+	}
 }


### PR DESCRIPTION
I'm using this module for convert many coordinates. I thought `proj.CRSToCRS` was a little slow.
So, I added `Context` that prepares and reuses the execution environment inside `proj.CRSToCRS`.

It's a benchmark results. Almost 30x faster.
```
goos: darwin
goarch: amd64
pkg: github.com/everystreet/go-proj/v6/proj
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkCRSToCRS
BenchmarkCRSToCRS-16    	     129	   8829673 ns/op
BenchmarkContext
BenchmarkContext-16     	 3911210	       296.9 ns/op
PASS
```

It would be good to change the execution structure inside "proj.CRSToCRS" to use "Context" to reduce duplicated code.

Please review and merge this commit. Thanks.
